### PR TITLE
Update Memento to v0.7.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 IterativeSolvers 0.4.1
-Memento 0.5.1
+Memento 0.7.0
 SimpleWeightedGraphs 0.3.0
 LightGraphs 0.11.0
 AMG 0.1.2


### PR DESCRIPTION
Fixing the dep warn broke dependency on earlier versions (#131), so this bump is required.