### PR TITLE
Pkg.checkout not supported anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ julia> Pkg.add("Circuitscape")
 If you want the latest development version, you can additionally do: 
 
 ```julia
-julia> Pkg.checkout("Circuitscape")
+julia> Pkg.add(PackageSpec(name="Circuitscape", rev="master"))
 ```
 
 Check if all the tests are passing by doing the following:


### PR DESCRIPTION
Unless Im mistaken, `Pkg.checkout` doesn't work anymore (doc: https://julialang.github.io/Pkg.jl/v1/managing-packages/#Adding-packages-1). I believe this is the correct way:
`Pkg.add(PackageSpec(name="Circuitscape", rev="master"))`