### PR TITLE
Fix InexactError in Read Raster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 Manifest.toml
 temp/
 **/*.properties
+local

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AlgebraicMultigrid = "0.2"
-ArchGDAL = "0.3.1"
+ArchGDAL = "0.3.1, 0.4.0"
 GZip = "0.5.1"
 IterativeSolvers = "0.7"
 LightGraphs = "1"

--- a/src/io.jl
+++ b/src/io.jl
@@ -450,6 +450,9 @@ function read_raster(path::String, T)
 
     # Extract the array
     array_t = ArchGDAL.read(band)
+
+    # This handles UInt tiff rasters that can still have negative NoData values
+    # Need to convert the NoData value to Int64 in these cases
     if eltype(array_t) <: Integer
         ras_type = Int64
     else

--- a/src/io.jl
+++ b/src/io.jl
@@ -456,8 +456,10 @@ function read_raster(path::String, T)
         ras_type = eltype(array_t)
     end
 
-    # Extract no data value and overwrite with Circuitscape/Omniscape default
-    nodata_val = convert(ras_type, ArchGDAL.getnodatavalue(band))
+    # Extract no data value, first converting it to the proper type (based on
+    # the raster). Then, need to convert to T. Weird, yes,
+    # but it's the only way I could get it to work for all raster types...
+    nodata_val = convert(T, convert(ras_type, ArchGDAL.getnodatavalue(band)))
 
     # Transpose the array -- ArchGDAL returns a x by y array, need y by x
     array = convert(Array{T}, permutedims(array_t, [2, 1]))


### PR DESCRIPTION
Closes #239. In `read_raster`, convert array to Float before proceeding with any array operations so that Int types can be handled without error (particularly in the assignment of -9999.0 NoData values).