### PR TITLE
add informative error throw if node file (point_file) contains non-integers

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -134,9 +134,21 @@ function _guess_file_type(filename, f)
 end
 
 function read_polymap(T, file::String, habitatmeta;
-                      nodata_as = 0, resample = true) # TODO remove unused argument -VL
+                      nodata_as = 0, resample = true) # TODO remove resample -VL
 
-    polymap, rastermeta = _grid_reader(T, file)
+    polymap, rastermeta = _grid_reader(Float64, file)
+
+    # Convert polymap to T. It's easier to do here and check for errors than
+    # to add another Boolean flag argument to read_raster that specifies if the
+    # file is for nodes points or polygons.
+    try
+        polymap = convert(Array{T}, polymap)
+    catch e
+        isa(e, InexactError) && @error string("Your node file (point_file in ",
+                                       "the .ini) contains non-integer values.",
+                                       " See the docs on specifying nodes for",
+                                       " more information.")
+    end
 
     ind = findall(x -> x == rastermeta.nodata, polymap)
     if nodata_as != -1

--- a/src/io.jl
+++ b/src/io.jl
@@ -134,7 +134,7 @@ function _guess_file_type(filename, f)
 end
 
 function read_polymap(T, file::String, habitatmeta;
-                      nodata_as = 0, resample = true) # TODO remove resample -VL
+                      nodata_as = 0)
 
     polymap, rastermeta = _grid_reader(Float64, file)
 


### PR DESCRIPTION
Related and in response to #257, closes #258. Throw an error if the point_file contains non-integer values. Circuitscape originally converted point_file to Int64 (or Int32, based on the `T` argument) inside `read_raster`. 

I pulled the conversion of the node array out of `_grid_reader` and `read_raster` to avoid making changes to `read_raster` that would have downstream implications for Omniscape, and to make this error only possible when reading the point_file via `read_polymap`.

With this fix, if you have a point_file with non integers, you will get output like this:
```julia
┌ Error: Your node file (point_file in the .ini) contains non-integer values. See the docs on specifying nodes for more information.
└ @ Circuitscape /home/omniscape/src/io.jl:147
ERROR: InexactError: Int64(0.0010000000474974513)
Stacktrace:
 [1] Int64 at ./float.jl:710 [inlined]
 [2] _broadcast_getindex_evalf at ./broadcast.jl:648 [inlined]
 [3] _broadcast_getindex at ./broadcast.jl:621 [inlined]
 [4] getindex at ./broadcast.jl:575 [inlined]
 [5] macro expansion at ./broadcast.jl:932 [inlined]
 [6] macro expansion at ./simdloop.jl:77 [inlined]
 [7] copyto! at ./broadcast.jl:931 [inlined]
 [8] copyto! at ./broadcast.jl:886 [inlined]
 [9] copy(::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},Type{Int64},Tuple{Array{Float64,1}}}) at ./broadcast.jl:862
 [10] materialize at ./broadcast.jl:837 [inlined]
 [11] read_point_map(::Type{T} where T, ::String, ::Circuitscape.RasterMeta) at /home/Circuitscape/src/io.jl:225
 [12] load_raster_data(::Type{T} where T, ::Type{T} where T, ::Dict{String,String}) at /home/Circuitscape/src/io.jl:415
 [13] raster_pairwise(::Type{T} where T, ::Type{T} where T, ::Dict{String,String}) at /home/Circuitscape/src/raster/pairwise.jl:18
 [14] _compute(::Type{T} where T, ::Type{T} where T, ::Dict{String,String}) at /home/Circuitscape/src/run.jl:42
 [15] macro expansion at ./timing.jl:233 [inlined]
 [16] compute(::String) at /home/Circuitscape/src/run.jl:31
 [17] top-level scope at untitled-63407bae533d0dff06914a870a28bed2:2
 [18] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1088
```
cc @ViralBShah 