### PR TITLE
Pass the suppress_messages arg to some functions new to 5.8.0

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -290,9 +290,9 @@ function _check_eltype(a, solver::CholmodSolver)
 end
 _check_eltype(a, solver::MKLPardisoSolver) = a
 
-function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, MKLPardisoSolver}, flags, 
+function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, MKLPardisoSolver}, flags,
                                   cfg, log) where {T,V}
-    
+
     # Data
     a = prob.G
     cc = prob.cc
@@ -493,12 +493,12 @@ end
 
 # TODO: In the pardiso case, we're not really constructing the factor
 # So can we make this consistent?
-function construct_cholesky_factor(matrix, ::CholmodSolver)
+function construct_cholesky_factor(matrix, ::CholmodSolver, suppress_info::Bool)
     t = @elapsed factor = cholesky(matrix + sparse(10eps()*I,size(matrix)...))
-    csinfo("Time taken to construct cholesky factor = $t")
+    csinfo("Time taken to construct cholesky factor = $t", suppress_messages)
     factor
 end
-construct_cholesky_factor(matrix, ::MKLPardisoSolver) = 
+construct_cholesky_factor(matrix, ::MKLPardisoSolver, suppress_info::Bool) = 
             MKLPardisoFactorize()
 
 
@@ -610,8 +610,8 @@ function sum_off_diag(G, i)
  end
 
 function solve_linear_system(
-            G::SparseMatrixCSC{T,V}, 
-            curr::Vector{T}, M)::Vector{T} where {T,V} 
+            G::SparseMatrixCSC{T,V},
+            curr::Vector{T}, M)::Vector{T} where {T,V}
     v = cg(G, curr, Pl = M, reltol = T(1e-6), maxiter = 100_000)
     @assert norm(G*v - curr) < 1e-5
     v
@@ -622,7 +622,7 @@ function solve_linear_system(factor::MKLPardisoFactorize, matrix, rhs)
     mat = sparse(10eps()*I,size(matrix)...) + matrix
     x = zeros(eltype(matrix), size(matrix, 1))
     for i = 1:size(lhs, 2)
-        factor(x, mat, rhs[:,i]) 
+        factor(x, mat, rhs[:,i])
         @assert norm(mat*x - rhs[:,i]) < 1e-5
         lhs[:,i] .= x
     end

--- a/src/core.jl
+++ b/src/core.jl
@@ -68,14 +68,14 @@ end
 function get_solver(cfg)
     s = cfg["solver"]
     if s in AMG
-        csinfo("Solver used: AMG accelerated by CG")
+        csinfo("Solver used: AMG accelerated by CG", cfg["suppress_messages"] in TRUELIST)
         return AMGSolver()
     elseif s in CHOLMOD
-        csinfo("Solver used: CHOLMOD")
+        csinfo("Solver used: CHOLMOD", cfg["suppress_messages"] in TRUELIST)
         bs = parse(Int, cfg["cholmod_batch_size"])
         return CholmodSolver(bs)
     elseif s in MKLPARDISO
-        csinfo("Solver used: MKLPardiso")
+        csinfo("Solver used: MKLPardiso", cfg["suppress_messages"] in TRUELIST)
         bs = parse(Int, cfg["cholmod_batch_size"])
         return MKLPardisoSolver(bs)
     end

--- a/src/core.jl
+++ b/src/core.jl
@@ -495,7 +495,7 @@ end
 # So can we make this consistent?
 function construct_cholesky_factor(matrix, ::CholmodSolver, suppress_info::Bool)
     t = @elapsed factor = cholesky(matrix + sparse(10eps()*I,size(matrix)...))
-    csinfo("Time taken to construct cholesky factor = $t", suppress_messages)
+    csinfo("Time taken to construct cholesky factor = $t", suppress_info)
     factor
 end
 construct_cholesky_factor(matrix, ::MKLPardisoSolver, suppress_info::Bool) = 

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -23,7 +23,7 @@ function raster_advanced(T, V, cfg)::Matrix{T}
     flags = get_raster_flags(cfg)
 
 
-    # Generate advanced 
+    # Generate advanced
     advanced_data = compute_advanced_data(rasterdata, flags, cfg)
 
     # Send to main kernel
@@ -33,7 +33,7 @@ function raster_advanced(T, V, cfg)::Matrix{T}
 end
 
 
-function compute_advanced_data(data::RasterData{T,V}, 
+function compute_advanced_data(data::RasterData{T,V},
                         flags,cfg)::AdvancedProblem{T,V} where {T,V}
 
     # Data
@@ -65,7 +65,7 @@ function compute_advanced_data(data::RasterData{T,V},
     solver = get_solver(cfg)
 
     AdvancedProblem(G, cc, nodemap, polymap, hbmeta,
-                sources, grounds, source_map, 
+                sources, grounds, source_map,
                 finite_grounds, V(-1), V(0), cellmap, solver)
 
 end
@@ -151,7 +151,7 @@ end
 
 function advanced_kernel(prob::AdvancedProblem{T,V,S}, flags, cfg)::Tuple{Matrix{T},Matrix{T}} where {T,V,S}
 
-    # Data 
+    # Data
     G = prob.G
     nodemap = prob.nodemap
     polymap = prob.polymap
@@ -202,7 +202,7 @@ function advanced_kernel(prob::AdvancedProblem{T,V,S}, flags, cfg)::Tuple{Matrix
         else
             f_local = finitegrounds
         end
-    
+
         voltages = multiple_solver(cfg, prob.solver, a_local, s_local, g_local, f_local)
 
         local_nodemap = construct_local_node_map(nodemap, c, polymap)
@@ -288,7 +288,7 @@ function multiple_solver(cfg, solver, a::SparseMatrixCSC{T,V}, sources, grounds,
     deleteat!(r, dst_del)
     asolve = asolve[r, r]
 
-    volt = multiple_solve(solver, asolve, sources)
+    volt = multiple_solve(solver, asolve, sources, cfg["suppress_messages"] in TRUELIST)
 
     # Replace the inf with 0
     voltages = zeros(eltype(a), length(volt) + length(infgrounds))
@@ -305,28 +305,28 @@ function multiple_solver(cfg, solver, a::SparseMatrixCSC{T,V}, sources, grounds,
     voltages
 end
 
-function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
+function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}, suppress_info::Bool) where {T,V}
     t1 = @elapsed M = aspreconditioner(smoothed_aggregation(matrix))
-    csinfo("Time taken to construct preconditioner = $t1 seconds")
+    csinfo("Time taken to construct preconditioner = $t1 seconds", suppress_info)
     t1 = @elapsed volt = solve_linear_system(matrix, sources, M)
     @assert norm(matrix*volt .- sources) < 1e-5
-    csinfo("Time taken to solve linear system = $t1 seconds")
+    csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
 
-function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
+function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}, suppress_info::Bool) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     @assert norm(matrix*volt .- sources) < 1e-5
-    csinfo("Time taken to solve linear system = $t1 seconds")
+    csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
 
-function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
+function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}, suppress_info::Bool) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     @assert norm(matrix*volt .- sources) < 1e-5
-    csinfo("Time taken to solve linear system = $t1 seconds")
+    csinfo("Time taken to solve linear system = $t1 seconds", supress_info)
     volt
 end
 

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -315,7 +315,7 @@ function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vec
 end
 
 function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}, suppress_info::Bool) where {T,V}
-    factor = construct_cholesky_factor(matrix, s)
+    factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     @assert norm(matrix*volt .- sources) < 1e-5
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
@@ -323,7 +323,7 @@ function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources:
 end
 
 function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}, suppress_info::Bool) where {T,V}
-    factor = construct_cholesky_factor(matrix, s)
+    factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     @assert norm(matrix*volt .- sources) < 1e-5
     csinfo("Time taken to solve linear system = $t1 seconds", supress_info)

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -326,7 +326,7 @@ function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sourc
     factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     @assert norm(matrix*volt .- sources) < 1e-5
-    csinfo("Time taken to solve linear system = $t1 seconds", supress_info)
+    csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
 


### PR DESCRIPTION
The `csinfo()` calls in `multiple_solve()` as well as for printing the solver used did not have `cfg["suppress_messages"]` passed in as an arg. Added `suppress_messages::Bool` as an arg to `multiple_solve()` and pass it into `csinfo()` calls where the default value of `false` was previously being used.