### PR TITLE
Reduce error tolerance for matrix norms when using single precision

### DIFF
--- a/src/consts.jl
+++ b/src/consts.jl
@@ -39,3 +39,7 @@ const INFO = ["INFO", "info", "Info"]
 const DEBUG = ["DEBUG", "debug", "Debug"]
 const WARNING = ["WARNING", "WARN", "warning", "warn", "Warning", "Warn"]
 const CRITICAL = ["CRITICAL", "critical", "Critical"]
+
+# Constants for tolerance when checking matrix norms
+const TOL_SINGLE = 1e-4
+const TOL_DOUBLE = 1e-5

--- a/src/consts.jl
+++ b/src/consts.jl
@@ -41,5 +41,5 @@ const WARNING = ["WARNING", "WARN", "warning", "warn", "Warning", "Warn"]
 const CRITICAL = ["CRITICAL", "critical", "Critical"]
 
 # Constants for tolerance when checking matrix norms
-const TOL_SINGLE = 1e-4
+const TOL_SINGLE = 1e-3
 const TOL_DOUBLE = 1e-5

--- a/src/core.jl
+++ b/src/core.jl
@@ -613,7 +613,7 @@ function solve_linear_system(
             G::SparseMatrixCSC{T,V},
             curr::Vector{T}, M)::Vector{T} where {T,V}
     v = cg(G, curr, Pl = M, reltol = T(1e-6), maxiter = 100_000)
-    @assert norm(G*v - curr) < (eltype(curr) == Float64 ? 1e-5 : 2e-5)
+    @assert norm(G*v - curr) < (eltype(curr) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
     v
 end
 
@@ -623,7 +623,7 @@ function solve_linear_system(factor::MKLPardisoFactorize, matrix, rhs)
     x = zeros(eltype(matrix), size(matrix, 1))
     for i = 1:size(lhs, 2)
         factor(x, mat, rhs[:,i])
-        @assert norm(mat*x - rhs[:,i]) < (eltype(matrix) == Float64 ? 1e-5 : 2e-5)
+        @assert norm(mat*x - rhs[:,i]) < (eltype(matrix) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
         lhs[:,i] .= x
     end
     lhs
@@ -632,7 +632,7 @@ end
 function solve_linear_system(factor::SuiteSparse.CHOLMOD.Factor, matrix, rhs)
     lhs = factor \ rhs
     for i = 1:size(rhs, 2)
-        @assert norm(matrix*lhs[:,i] - rhs[:,i]) < (eltype(matrix) == Float64 ? 1e-5 : 2e-5)
+        @assert norm(matrix*lhs[:,i] - rhs[:,i]) < (eltype(matrix) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
     end
     lhs
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -290,9 +290,9 @@ function _check_eltype(a, solver::CholmodSolver)
 end
 _check_eltype(a, solver::MKLPardisoSolver) = a
 
-function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, MKLPardisoSolver}, flags, 
+function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, MKLPardisoSolver}, flags,
                                   cfg, log) where {T,V}
-    
+
     # Data
     a = prob.G
     cc = prob.cc
@@ -498,7 +498,7 @@ function construct_cholesky_factor(matrix, ::CholmodSolver)
     csinfo("Time taken to construct cholesky factor = $t")
     factor
 end
-construct_cholesky_factor(matrix, ::MKLPardisoSolver) = 
+construct_cholesky_factor(matrix, ::MKLPardisoSolver) =
             MKLPardisoFactorize()
 
 
@@ -610,10 +610,10 @@ function sum_off_diag(G, i)
  end
 
 function solve_linear_system(
-            G::SparseMatrixCSC{T,V}, 
-            curr::Vector{T}, M)::Vector{T} where {T,V} 
+            G::SparseMatrixCSC{T,V},
+            curr::Vector{T}, M)::Vector{T} where {T,V}
     v = cg(G, curr, Pl = M, reltol = T(1e-6), maxiter = 100_000)
-    @assert norm(G*v - curr) < 1e-5
+    @assert norm(G*v - curr) < (eltype(curr) == Float64 ? 1e-5 : 2e-5)
     v
 end
 
@@ -622,8 +622,8 @@ function solve_linear_system(factor::MKLPardisoFactorize, matrix, rhs)
     mat = sparse(10eps()*I,size(matrix)...) + matrix
     x = zeros(eltype(matrix), size(matrix, 1))
     for i = 1:size(lhs, 2)
-        factor(x, mat, rhs[:,i]) 
-        @assert norm(mat*x - rhs[:,i]) < 1e-5
+        factor(x, mat, rhs[:,i])
+        @assert norm(mat*x - rhs[:,i]) < (eltype(matrix) == Float64 ? 1e-5 : 2e-5)
         lhs[:,i] .= x
     end
     lhs
@@ -632,7 +632,7 @@ end
 function solve_linear_system(factor::SuiteSparse.CHOLMOD.Factor, matrix, rhs)
     lhs = factor \ rhs
     for i = 1:size(rhs, 2)
-        @assert norm(matrix*lhs[:,i] - rhs[:,i]) < 1e-5
+        @assert norm(matrix*lhs[:,i] - rhs[:,i]) < (eltype(matrix) == Float64 ? 1e-5 : 2e-5)
     end
     lhs
 end

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -23,7 +23,7 @@ function raster_advanced(T, V, cfg)::Matrix{T}
     flags = get_raster_flags(cfg)
 
 
-    # Generate advanced 
+    # Generate advanced
     advanced_data = compute_advanced_data(rasterdata, flags, cfg)
 
     # Send to main kernel
@@ -33,7 +33,7 @@ function raster_advanced(T, V, cfg)::Matrix{T}
 end
 
 
-function compute_advanced_data(data::RasterData{T,V}, 
+function compute_advanced_data(data::RasterData{T,V},
                         flags,cfg)::AdvancedProblem{T,V} where {T,V}
 
     # Data
@@ -65,7 +65,7 @@ function compute_advanced_data(data::RasterData{T,V},
     solver = get_solver(cfg)
 
     AdvancedProblem(G, cc, nodemap, polymap, hbmeta,
-                sources, grounds, source_map, 
+                sources, grounds, source_map,
                 finite_grounds, V(-1), V(0), cellmap, solver)
 
 end
@@ -151,7 +151,7 @@ end
 
 function advanced_kernel(prob::AdvancedProblem{T,V,S}, flags, cfg)::Tuple{Matrix{T},Matrix{T}} where {T,V,S}
 
-    # Data 
+    # Data
     G = prob.G
     nodemap = prob.nodemap
     polymap = prob.polymap
@@ -202,7 +202,7 @@ function advanced_kernel(prob::AdvancedProblem{T,V,S}, flags, cfg)::Tuple{Matrix
         else
             f_local = finitegrounds
         end
-    
+
         voltages = multiple_solver(cfg, prob.solver, a_local, s_local, g_local, f_local)
 
         local_nodemap = construct_local_node_map(nodemap, c, polymap)
@@ -309,7 +309,7 @@ function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vec
     t1 = @elapsed M = aspreconditioner(smoothed_aggregation(matrix))
     csinfo("Time taken to construct preconditioner = $t1 seconds")
     t1 = @elapsed volt = solve_linear_system(matrix, sources, M)
-    @assert norm(matrix*volt .- sources) < 1e-5
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end
@@ -317,7 +317,7 @@ end
 function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
-    @assert norm(matrix*volt .- sources) < 1e-5
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end
@@ -325,7 +325,7 @@ end
 function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
-    @assert norm(matrix*volt .- sources) < 1e-5
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -309,7 +309,7 @@ function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vec
     t1 = @elapsed M = aspreconditioner(smoothed_aggregation(matrix))
     csinfo("Time taken to construct preconditioner = $t1 seconds")
     t1 = @elapsed volt = solve_linear_system(matrix, sources, M)
-    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end
@@ -317,7 +317,7 @@ end
 function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
-    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end
@@ -325,7 +325,7 @@ end
 function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sources::Vector{T}) where {T,V}
     factor = construct_cholesky_factor(matrix, s)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
-    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? 1e-5 : 2e-5)
+    @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
     csinfo("Time taken to solve linear system = $t1 seconds")
     volt
 end


### PR DESCRIPTION
I had to increase the tolerance of error for the matrix norm testing to `1e-3` when using single precision. The tolerance is `1e-5` when using double. I have confirmed that this stops the `AssertError` from being thrown in the Omniscape test that was failing (and did not fail when I changed the test parameter to use double precision). 

If it is any consolation, regardless of the error in the matrix norm, using `Float32` yields pretty much the exact current map as using `Float64` ([these tests](https://github.com/Circuitscape/Omniscape.jl/blob/main/test/runtests.jl#L121-L123) pass in Omniscape regardless of the precision used -- a good sign).

This may be related to #288, but we have not confirmed with the user whether single precision is being used there. I suspect it is, but we will verify before closing that issue.