### PR TITLE
builder passed incorrect value to habitat_map_is_resistances,

### DIFF
--- a/src/INIBuilder/run.jl
+++ b/src/INIBuilder/run.jl
@@ -40,10 +40,10 @@ function step3()
     cfg["habitat_file"] = path
     println()
     println("Is this a resistance or conductance file?")
-    is_res = ["PREVIOUS STEP", "resistances", "conductance"]
+    is_res = ["PREVIOUS STEP", "resistance", "conductance"]
     n = request(RadioMenu(is_res))
     n == 1 && step2()
-    cfg["habitat_map_is_resistances"] = is_res[n]
+    cfg["habitat_map_is_resistances"] = is_res[n] == "resistance" ? "true" : "false"
     step4() 
 end
 


### PR DESCRIPTION
`start()` was passing the incorrect value to `cfg["habitat_map_is_resistances"]`. Needs "true" or "false", was getting "resistances" or "conductance". Tested this locally and it seemed to work. Closes #312.