### PR TITLE
Make assertion check consistent with iterativesolvers.jl 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Circuitscape"
 uuid = "2b7a1792-8151-5239-925d-e2b8fdfa3201"
-version = "5.11"
+version = "5.11.0"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"

--- a/src/Circuitscape.jl
+++ b/src/Circuitscape.jl
@@ -7,8 +7,6 @@ using SimpleWeightedGraphs
 using IterativeSolvers
 using GZip
 using Pardiso
-using JLD2
-using FileIO
 
 using LinearAlgebra
 using SparseArrays

--- a/src/Circuitscape.jl
+++ b/src/Circuitscape.jl
@@ -7,6 +7,8 @@ using SimpleWeightedGraphs
 using IterativeSolvers
 using GZip
 using Pardiso
+using JLD2
+using FileIO
 
 using LinearAlgebra
 using SparseArrays

--- a/src/core.jl
+++ b/src/core.jl
@@ -613,7 +613,7 @@ function solve_linear_system(
             G::SparseMatrixCSC{T,V},
             curr::Vector{T}, M)::Vector{T} where {T,V}
     v = cg(G, curr, Pl = M, reltol = T(1e-6), maxiter = 100_000)
-	@assert (norm(G*v .- curr, Inf) / norm(v, Inf)) < 1e-5
+	@assert norm(G*v .- curr) / norm(curr) < 1e-6
     v
 end
 
@@ -623,7 +623,7 @@ function solve_linear_system(factor::MKLPardisoFactorize, matrix, rhs)
     x = zeros(eltype(matrix), size(matrix, 1))
     for i = 1:size(lhs, 2)
         factor(x, mat, rhs[:,i])
-		@assert (norm(mat*x .- rhs[:,i], Inf) / norm(x, Inf)) < 1e-5
+		@assert (norm(mat*x .- rhs[:,i]) / norm(rhs[:,i])) < 1e-6
         lhs[:,i] .= x
     end
     lhs
@@ -632,7 +632,7 @@ end
 function solve_linear_system(factor::SuiteSparse.CHOLMOD.Factor, matrix, rhs)
     lhs = factor \ rhs
     for i = 1:size(rhs, 2)
-		@assert (norm(matrix*lhs[:,i] .- rhs[:,i], Inf) / norm(lhs[:,i], Inf)) < 1e-5
+		@assert (norm(matrix*lhs[:,i] .- rhs[:,i]) / norm(rhs[:,i])) < 1e-6
     end
     lhs
 end

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -311,7 +311,7 @@ function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vec
     csinfo("Time taken to construct preconditioner = $t1 seconds", suppress_info)
     t1 = @elapsed volt = solve_linear_system(matrix, sources, M)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources, Inf) / norm(volt, Inf)) < 1e-5
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
@@ -320,7 +320,7 @@ function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources:
     factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources, Inf) / norm(volt, Inf)) < 1e-5
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
@@ -329,7 +329,7 @@ function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sourc
     factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources, Inf) / norm(volt, Inf)) < 1e-5
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end


### PR DESCRIPTION
Should not normalize by the lhs, but by the rhs instead, like in IterativeSolvers.jl. Also use L2 norm like in IterativeSolvers.jl 