### PR TITLE
increase solve error tolerance from 1e-6 to 1e-4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Circuitscape"
 uuid = "2b7a1792-8151-5239-925d-e2b8fdfa3201"
-version = "5.13.1"
+version = "5.13.2"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"

--- a/lib/CircuitscapeMKLPardiso/src/CircuitscapeMKLPardiso.jl
+++ b/lib/CircuitscapeMKLPardiso/src/CircuitscapeMKLPardiso.jl
@@ -50,7 +50,7 @@ function solve_linear_system(factor::MKLPardisoFactorize, matrix, rhs)
     x = zeros(eltype(matrix), size(matrix, 1))
     for i = 1:size(lhs, 2)
         factor(x, mat, rhs[:,i])
-		@assert (norm(mat*x .- rhs[:,i]) / norm(rhs[:,i])) < 1e-6
+		@assert (norm(mat*x .- rhs[:,i]) / norm(rhs[:,i])) < 1e-4
         lhs[:,i] .= x
     end
     lhs

--- a/src/core.jl
+++ b/src/core.jl
@@ -610,7 +610,7 @@ function solve_linear_system(
             G::SparseMatrixCSC{T,V},
             curr::Vector{T}, M)::Vector{T} where {T,V}
     v = cg(G, curr, Pl = M, reltol = T(1e-6), maxiter = 100_000)
-	@assert norm(G*v .- curr) / norm(curr) < 1e-6
+	@assert norm(G*v .- curr) / norm(curr) < 1e-4
     v
 end
 
@@ -618,7 +618,7 @@ end
 function solve_linear_system(factor::SuiteSparse.CHOLMOD.Factor, matrix, rhs)
     lhs = factor \ rhs
     for i = 1:size(rhs, 2)
-		@assert (norm(matrix*lhs[:,i] .- rhs[:,i]) / norm(rhs[:,i])) < 1e-6
+		@assert (norm(matrix*lhs[:,i] .- rhs[:,i]) / norm(rhs[:,i])) < 1e-4
     end
     lhs
 end


### PR DESCRIPTION
Increases the error tolerance for solve accuracy. Closes #406.

Some related issues in Omniscape that this should hopefully address include https://github.com/Circuitscape/Omniscape.jl/issues/142, https://github.com/Circuitscape/Omniscape.jl/issues/127, https://github.com/Circuitscape/Omniscape.jl/issues/108, and https://github.com/Circuitscape/Omniscape.jl/issues/100.