### PR TITLE
Increase error tolerance for advanced mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Circuitscape"
 uuid = "2b7a1792-8151-5239-925d-e2b8fdfa3201"
-version = "5.13.2"
+version = "5.13.3"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -310,7 +310,7 @@ function multiple_solve(s::AMGSolver, matrix::SparseMatrixCSC{T,V}, sources::Vec
     csinfo("Time taken to construct preconditioner = $t1 seconds", suppress_info)
     t1 = @elapsed volt = solve_linear_system(matrix, sources, M)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-4
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
@@ -319,7 +319,7 @@ function multiple_solve(s::CholmodSolver, matrix::SparseMatrixCSC{T,V}, sources:
     factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-4
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end
@@ -328,7 +328,7 @@ function multiple_solve(s::MKLPardisoSolver, matrix::SparseMatrixCSC{T,V}, sourc
     factor = construct_cholesky_factor(matrix, s, suppress_info)
     t1 = @elapsed volt = solve_linear_system(factor, matrix, sources)
     # @assert norm(matrix*volt .- sources) < (eltype(sources) == Float64 ? TOL_DOUBLE : TOL_SINGLE)
-	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-6
+	@assert (norm(matrix*volt .- sources) / norm(sources)) < 1e-4
     csinfo("Time taken to solve linear system = $t1 seconds", suppress_info)
     volt
 end


### PR DESCRIPTION
I missed a few places in #407  (namely advanced mode, which is what Omniscape uses and causes the issues I mentioned in #406  🙃 ). This PR changes those last few holdouts to 1e-4.

I've also bumped a patch version. If we could register this patch release when this is merged, that would be excellent.