### PR TITLE
Fix INIBuilder ground file menu in advanced mode

### DIFF
--- a/src/INIBuilder/run.jl
+++ b/src/INIBuilder/run.jl
@@ -67,8 +67,9 @@ function step4()
         path = n == 2 ? manualfilepicker() : filepicker()
         cfg["source_file"] = path
         println()
-        println("Step 4b: Enter path to ground file") 
-        n = ["PREVIOUS STEP", "Enter path manually", "Use filepicker"]
+        println("Step 4b: Enter path to ground file")
+        opt = ["PREVIOUS STEP", "Enter path manually", "Use filepicker"]
+        n = request(RadioMenu(opt))
         n == 1 && step3()
         path = n == 2 ? manualfilepicker() : filepicker()
         cfg["ground_file"] = path


### PR DESCRIPTION
## Summary
- Fixed bug where the ground file selection menu in advanced mode assigned the options list directly to `n` instead of presenting a `RadioMenu`
- This made it impossible to select a ground file path in the INIBuilder's advanced mode flow

Closes #354

## Test plan
- [ ] Run `Circuitscape.INIBuilder.start()`, choose advanced mode, and verify ground file step presents a working menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)