### PR TITLE
Don't write cumulative current map when write_cur_maps is False

### DIFF
--- a/src/raster/onetoall.jl
+++ b/src/raster/onetoall.jl
@@ -156,7 +156,7 @@ function onetoall_kernel(data::RasterData{T,V}, flags, cfg)::Matrix{T} where {T,
 
     pmap(x -> f(x), 1:num_points_to_solve)
 
-    if flags.outputflags.write_cur_maps
+    if flags.outputflags.write_cur_maps || flags.outputflags.write_cum_cur_map_only
         write_cum_maps(cum, gmap, cfg, hbmeta,
                        flags.outputflags.write_max_cur_maps,
                        flags.outputflags.write_cum_cur_map_only)

--- a/src/raster/pairwise.jl
+++ b/src/raster/pairwise.jl
@@ -62,9 +62,11 @@ function _pt_file_no_polygons_path(rasterdata::RasterData{T,V},
     graphdata = compute_graph_data_no_polygons(rasterdata, flags, cfg)
     r = single_ground_all_pairs(graphdata, flags, cfg)
 
-    write_cum_maps(graphdata.cum, rasterdata.cellmap, cfg, rasterdata.hbmeta,
-                    flags.outputflags.write_max_cur_maps,
-                    flags.outputflags.write_cum_cur_map_only)
+    if flags.outputflags.write_cur_maps || flags.outputflags.write_cum_cur_map_only
+        write_cum_maps(graphdata.cum, rasterdata.cellmap, cfg, rasterdata.hbmeta,
+                        flags.outputflags.write_max_cur_maps,
+                        flags.outputflags.write_cum_cur_map_only)
+    end
 
     r
 end
@@ -123,9 +125,11 @@ function _pt_file_polygons_path(rasterdata::RasterData{T,V},
     P = [0, pts...]
     r = hcat(P, vcat(pts', resistances))
 
-    write_cum_maps(cum, gmap, cfg, rasterdata.hbmeta,
-                   flags.outputflags.write_max_cur_maps,
-                   flags.outputflags.write_cum_cur_map_only)
+    if flags.outputflags.write_cur_maps || flags.outputflags.write_cum_cur_map_only
+        write_cum_maps(cum, gmap, cfg, rasterdata.hbmeta,
+                       flags.outputflags.write_max_cur_maps,
+                       flags.outputflags.write_cum_cur_map_only)
+    end
 
     # save resistances
     save_resistances(r, cfg)

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -211,3 +211,11 @@ end
 # Users with dots in their names - issue #181
 # Just check that this does not break
 #compute("input/raster/extra.one/1/oneToAllVerify1.ini")
+
+# Issue 158: cumulative current map should not be produced when write_cur_maps=False
+let
+    cum_file = "output/sgVerify12_cum_curmap.asc"
+    isfile(cum_file) && rm(cum_file)
+    compute("input/raster/pairwise/12/sgVerify12.ini")
+    @test !isfile(cum_file)
+end


### PR DESCRIPTION
## Summary
- Guard `write_cum_maps` calls in both pairwise paths (with/without polygons) so cumulative maps are only written when `write_cur_maps` or `write_cum_cur_map_only` is `True`
- Fix the same missing `write_cum_cur_map_only` guard in `onetoall.jl`
- Add test verifying no `cum_curmap.asc` file is produced when `write_cur_maps=False`

Previously a cumulative current map filled with zeros was always written to disk in pairwise mode.

Closes #158

## Test plan
- [x] Existing 719 tests pass
- [x] New test: verify no cumulative map file when `write_cur_maps=False` (uses existing test case 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)