### PR TITLE
Replace Dict{String,String} config with typed CSConfig struct

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -1,3 +1,240 @@
+@enum DataType dt_raster dt_network
+@enum Scenario sc_pairwise sc_advanced sc_onetoall sc_alltoone
+@enum SolverType st_cg_amg st_cholmod st_pardiso
+@enum Precision pr_single pr_double
+@enum LogLevel ll_none ll_info ll_debug ll_warning ll_critical
+@enum RemovePolicy rp_keepall rp_rmvsrc rp_rmvgnd rp_rmvall
+
+Base.@kwdef struct CSConfig
+    version::String = "unknown"
+    data_type::DataType = dt_raster
+    scenario::Scenario = sc_pairwise
+    habitat_file::String = ""
+    habitat_map_is_resistances::Bool = true
+    connect_four_neighbors_only::Bool = false
+    connect_using_avg_resistances::Bool = false
+    use_polygons::Bool = false
+    polygon_file::String = ""
+    source_file::String = ""
+    ground_file::String = ""
+    ground_file_is_resistances::Bool = true
+    use_unit_currents::Bool = false
+    use_direct_grounds::Bool = false
+    remove_src_or_gnd::RemovePolicy = rp_keepall
+    use_mask::Bool = false
+    mask_file::String = ""
+    solver::SolverType = st_cg_amg
+    parallelize::Bool = false
+    max_parallel::Int = 0
+    precision::Precision = pr_double
+    use_64bit_indexing::Bool = true
+    cholmod_batch_size::Int = 1000
+    low_memory_mode::Bool = false
+    preemptive_memory_release::Bool = false
+    use_variable_source_strengths::Bool = false
+    variable_source_file::String = ""
+    use_included_pairs::Bool = false
+    included_pairs_file::String = ""
+    point_file::String = ""
+    use_reclass_table::Bool = false
+    reclass_file::String = ""
+    output_file::String = ""
+    write_cur_maps::Bool = false
+    write_volt_maps::Bool = false
+    write_cum_cur_map_only::Bool = false
+    write_max_cur_maps::Bool = false
+    set_null_currents_to_nodata::Bool = false
+    set_null_voltages_to_nodata::Bool = false
+    set_focal_node_currents_to_zero::Bool = false
+    compress_grids::Bool = false
+    log_transform_maps::Bool = false
+    write_as_tif::Bool = false
+    log_file::String = ""
+    log_level::LogLevel = ll_info
+    suppress_messages::Bool = false
+end
+
+function _parse_bool(dict, key, default="false")
+    get(dict, key, default) in ("True", "true", "1")
+end
+
+_parse_data_type(s) = s in RASTER ? dt_raster : dt_network
+
+function _parse_scenario(s)
+    s in PAIRWISE ? sc_pairwise :
+    s in ADVANCED ? sc_advanced :
+    s in ONETOALL ? sc_onetoall :
+    s in ALLTOONE ? sc_alltoone : sc_pairwise
+end
+
+function _parse_solver(s)
+    s in AMG ? st_cg_amg :
+    s in CHOLMOD ? st_cholmod :
+    s in PARDISO ? st_pardiso : st_cg_amg
+end
+
+_parse_precision(s) = s in SINGLE ? pr_single : pr_double
+
+function _parse_log_level(s)
+    s in NONE ? ll_none :
+    s in INFO ? ll_info :
+    s in DEBUG ? ll_debug :
+    s in WARNING ? ll_warning :
+    s in CRITICAL ? ll_critical : ll_info
+end
+
+function _parse_remove_policy(s)
+    s == "rmvsrc" ? rp_rmvsrc :
+    s == "rmvgnd" ? rp_rmvgnd :
+    s == "rmvall" ? rp_rmvall : rp_keepall
+end
+
+function CSConfig(dict::Dict{String,String})
+    CSConfig(
+        version = get(dict, "version", "unknown"),
+        data_type = _parse_data_type(get(dict, "data_type", "raster")),
+        scenario = _parse_scenario(get(dict, "scenario", "not entered")),
+        habitat_file = get(dict, "habitat_file", ""),
+        habitat_map_is_resistances = _parse_bool(dict, "habitat_map_is_resistances", "True"),
+        connect_four_neighbors_only = _parse_bool(dict, "connect_four_neighbors_only"),
+        connect_using_avg_resistances = _parse_bool(dict, "connect_using_avg_resistances"),
+        use_polygons = _parse_bool(dict, "use_polygons"),
+        polygon_file = get(dict, "polygon_file", ""),
+        source_file = get(dict, "source_file", ""),
+        ground_file = get(dict, "ground_file", ""),
+        ground_file_is_resistances = _parse_bool(dict, "ground_file_is_resistances", "True"),
+        use_unit_currents = _parse_bool(dict, "use_unit_currents"),
+        use_direct_grounds = _parse_bool(dict, "use_direct_grounds"),
+        remove_src_or_gnd = _parse_remove_policy(get(dict, "remove_src_or_gnd", "keepall")),
+        use_mask = _parse_bool(dict, "use_mask"),
+        mask_file = get(dict, "mask_file", ""),
+        solver = _parse_solver(get(dict, "solver", "cg+amg")),
+        parallelize = _parse_bool(dict, "parallelize"),
+        max_parallel = parse(Int, get(dict, "max_parallel", "0")),
+        precision = _parse_precision(get(dict, "precision", "Double")),
+        use_64bit_indexing = _parse_bool(dict, "use_64bit_indexing", "true"),
+        cholmod_batch_size = parse(Int, get(dict, "cholmod_batch_size", "1000")),
+        low_memory_mode = _parse_bool(dict, "low_memory_mode"),
+        preemptive_memory_release = _parse_bool(dict, "preemptive_memory_release"),
+        use_variable_source_strengths = _parse_bool(dict, "use_variable_source_strengths"),
+        variable_source_file = get(dict, "variable_source_file", ""),
+        use_included_pairs = _parse_bool(dict, "use_included_pairs"),
+        included_pairs_file = get(dict, "included_pairs_file", ""),
+        point_file = get(dict, "point_file", ""),
+        use_reclass_table = _parse_bool(dict, "use_reclass_table"),
+        reclass_file = get(dict, "reclass_file", ""),
+        output_file = get(dict, "output_file", ""),
+        write_cur_maps = _parse_bool(dict, "write_cur_maps"),
+        write_volt_maps = _parse_bool(dict, "write_volt_maps"),
+        write_cum_cur_map_only = _parse_bool(dict, "write_cum_cur_map_only"),
+        write_max_cur_maps = _parse_bool(dict, "write_max_cur_maps"),
+        set_null_currents_to_nodata = _parse_bool(dict, "set_null_currents_to_nodata"),
+        set_null_voltages_to_nodata = _parse_bool(dict, "set_null_voltages_to_nodata"),
+        set_focal_node_currents_to_zero = _parse_bool(dict, "set_focal_node_currents_to_zero"),
+        compress_grids = _parse_bool(dict, "compress_grids"),
+        log_transform_maps = _parse_bool(dict, "log_transform_maps"),
+        write_as_tif = _parse_bool(dict, "write_as_tif"),
+        log_file = let v = get(dict, "log_file", "None"); v == "None" ? "" : v end,
+        log_level = _parse_log_level(get(dict, "log_level", "INFO")),
+        suppress_messages = _parse_bool(dict, "suppress_messages"),
+    )
+end
+
+# String converters for CSConfig fields
+_bool_str(v::Bool) = v ? "True" : "False"
+
+function _data_type_str(v::DataType)
+    v == dt_raster ? "raster" : "network"
+end
+
+function _scenario_str(v::Scenario)
+    v == sc_pairwise ? "pairwise" :
+    v == sc_advanced ? "advanced" :
+    v == sc_onetoall ? "one-to-all" :
+    v == sc_alltoone ? "all-to-one" : "pairwise"
+end
+
+function _solver_str(v::SolverType)
+    v == st_cg_amg ? "cg+amg" :
+    v == st_cholmod ? "cholmod" :
+    v == st_pardiso ? "mklpardiso" : "cg+amg"
+end
+
+_precision_str(v::Precision) = v == pr_single ? "single" : "double"
+
+function _log_level_str(v::LogLevel)
+    v == ll_none ? "NONE" :
+    v == ll_info ? "INFO" :
+    v == ll_debug ? "DEBUG" :
+    v == ll_warning ? "WARNING" :
+    v == ll_critical ? "CRITICAL" : "INFO"
+end
+
+function _remove_policy_str(v::RemovePolicy)
+    v == rp_keepall ? "keepall" :
+    v == rp_rmvsrc ? "rmvsrc" :
+    v == rp_rmvgnd ? "rmvgnd" :
+    v == rp_rmvall ? "rmvall" : "keepall"
+end
+
+function _remove_policy_symbol(v::RemovePolicy)
+    v == rp_keepall ? :keepall :
+    v == rp_rmvsrc ? :rmvsrc :
+    v == rp_rmvgnd ? :rmvgnd :
+    v == rp_rmvall ? :rmvall : :keepall
+end
+
+function Base.Dict{String,String}(cfg::CSConfig)
+    a = Dict{String,String}()
+    a["version"] = cfg.version
+    a["data_type"] = _data_type_str(cfg.data_type)
+    a["scenario"] = _scenario_str(cfg.scenario)
+    a["habitat_file"] = cfg.habitat_file
+    a["habitat_map_is_resistances"] = _bool_str(cfg.habitat_map_is_resistances)
+    a["connect_four_neighbors_only"] = _bool_str(cfg.connect_four_neighbors_only)
+    a["connect_using_avg_resistances"] = _bool_str(cfg.connect_using_avg_resistances)
+    a["use_polygons"] = _bool_str(cfg.use_polygons)
+    a["polygon_file"] = cfg.polygon_file
+    a["source_file"] = cfg.source_file
+    a["ground_file"] = cfg.ground_file
+    a["ground_file_is_resistances"] = _bool_str(cfg.ground_file_is_resistances)
+    a["use_unit_currents"] = _bool_str(cfg.use_unit_currents)
+    a["use_direct_grounds"] = _bool_str(cfg.use_direct_grounds)
+    a["remove_src_or_gnd"] = _remove_policy_str(cfg.remove_src_or_gnd)
+    a["use_mask"] = _bool_str(cfg.use_mask)
+    a["mask_file"] = cfg.mask_file
+    a["solver"] = _solver_str(cfg.solver)
+    a["parallelize"] = _bool_str(cfg.parallelize)
+    a["max_parallel"] = string(cfg.max_parallel)
+    a["precision"] = _precision_str(cfg.precision)
+    a["use_64bit_indexing"] = _bool_str(cfg.use_64bit_indexing)
+    a["cholmod_batch_size"] = string(cfg.cholmod_batch_size)
+    a["low_memory_mode"] = _bool_str(cfg.low_memory_mode)
+    a["preemptive_memory_release"] = _bool_str(cfg.preemptive_memory_release)
+    a["use_variable_source_strengths"] = _bool_str(cfg.use_variable_source_strengths)
+    a["variable_source_file"] = cfg.variable_source_file
+    a["use_included_pairs"] = _bool_str(cfg.use_included_pairs)
+    a["included_pairs_file"] = cfg.included_pairs_file
+    a["point_file"] = cfg.point_file
+    a["use_reclass_table"] = _bool_str(cfg.use_reclass_table)
+    a["reclass_file"] = cfg.reclass_file
+    a["output_file"] = cfg.output_file
+    a["write_cur_maps"] = _bool_str(cfg.write_cur_maps)
+    a["write_volt_maps"] = _bool_str(cfg.write_volt_maps)
+    a["write_cum_cur_map_only"] = _bool_str(cfg.write_cum_cur_map_only)
+    a["write_max_cur_maps"] = _bool_str(cfg.write_max_cur_maps)
+    a["set_null_currents_to_nodata"] = _bool_str(cfg.set_null_currents_to_nodata)
+    a["set_null_voltages_to_nodata"] = _bool_str(cfg.set_null_voltages_to_nodata)
+    a["set_focal_node_currents_to_zero"] = _bool_str(cfg.set_focal_node_currents_to_zero)
+    a["compress_grids"] = _bool_str(cfg.compress_grids)
+    a["log_transform_maps"] = _bool_str(cfg.log_transform_maps)
+    a["write_as_tif"] = _bool_str(cfg.write_as_tif)
+    a["log_file"] = cfg.log_file == "" ? "None" : cfg.log_file
+    a["log_level"] = _log_level_str(cfg.log_level)
+    a["suppress_messages"] = _bool_str(cfg.suppress_messages)
+    a
+end
+
 function parse_config(path::String)
     cf = init_config()
     f = open(path, "r")
@@ -11,10 +248,10 @@ function parse_config(path::String)
         cf[var] = val
     end
     close(f)
-    cf
+    CSConfig(cf)
 end
 
-# Defaults
+# Defaults - kept for backward compatibility (returns Dict{String,String})
 function init_config()
     a = Dict{String, String}()
 
@@ -79,63 +316,67 @@ function update!(cfg, new)
     end
 end
 
-function write_config(cfg)
-    open(cfg["output_file"], "w") do f
+function write_config(cfg::CSConfig)
+    open(cfg.output_file, "w") do f
         write(f, """
         [Circuitscape Mode]
-        data_type = $(cfg["data_type"])
-        scenario = $(cfg["scenario"])
+        data_type = $(_data_type_str(cfg.data_type))
+        scenario = $(_scenario_str(cfg.scenario))
 
         [Version]
         version = 5.0.0
 
         [Habitat raster or graph]
-        habitat_file = $(cfg["habitat_file"])
-        habitat_map_is_resistances = $(cfg["habitat_map_is_resistances"])
+        habitat_file = $(cfg.habitat_file)
+        habitat_map_is_resistances = $(cfg.habitat_map_is_resistances)
 
         [Connection Scheme for raster habitat data]
-        connect_four_neighbors_only = $(cfg["connect_four_neighbors_only"] in TRUELIST)
-        connect_using_avg_resistances = $(cfg["connect_using_avg_resistances"] in TRUELIST)
+        connect_four_neighbors_only = $(cfg.connect_four_neighbors_only)
+        connect_using_avg_resistances = $(cfg.connect_using_avg_resistances)
 
         [Short circuit regions (aka polygons)]
-        use_polygons = $(cfg["use_polygons"] in TRUELIST)
-        polygon_file = $(cfg["polygon_file"])
+        use_polygons = $(cfg.use_polygons)
+        polygon_file = $(cfg.polygon_file)
 
         [Options for advanced mode]
-        ground_file_is_resistances = $(cfg["ground_file_is_resistances"] in TRUELIST)
-        source_file = $(cfg["source_file"])
-        remove_src_or_gnd = $(cfg["remove_src_or_gnd"])
-        ground_file = $(cfg["ground_file"])
-        use_unit_currents = $(cfg["use_unit_currents"] in TRUELIST)
-        use_direct_grounds = $(cfg["use_direct_grounds"] in TRUELIST)
+        ground_file_is_resistances = $(cfg.ground_file_is_resistances)
+        source_file = $(cfg.source_file)
+        remove_src_or_gnd = $(_remove_policy_str(cfg.remove_src_or_gnd))
+        ground_file = $(cfg.ground_file)
+        use_unit_currents = $(cfg.use_unit_currents)
+        use_direct_grounds = $(cfg.use_direct_grounds)
 
         [Mask file]
-        use_mask = $(cfg["use_mask"] in TRUELIST)
-        mask_file = $(cfg["mask_file"])
+        use_mask = $(cfg.use_mask)
+        mask_file = $(cfg.mask_file)
 
         [Options for one-to-all and all-to-one modes]
-        use_variable_source_strengths = $(cfg["use_variable_source_strengths"] in TRUELIST)
-        variable_source_file = $(cfg["variable_source_file"])
+        use_variable_source_strengths = $(cfg.use_variable_source_strengths)
+        variable_source_file = $(cfg.variable_source_file)
 
         [Options for pairwise and one-to-all and all-to-one modes]
-        included_pairs_file = $(cfg["included_pairs_file"])
-        use_included_pairs = $(cfg["use_included_pairs"] in TRUELIST)
-        point_file = $(cfg["point_file"])
+        included_pairs_file = $(cfg.included_pairs_file)
+        use_included_pairs = $(cfg.use_included_pairs)
+        point_file = $(cfg.point_file)
 
         [Calculation options]
-		solver = $(cfg["solver"])
+        solver = $(_solver_str(cfg.solver))
 
         [Output options]
-        write_cum_cur_map_only = $(cfg["write_cum_cur_map_only"] in TRUELIST)
-        log_transform_maps = $(cfg["log_transform_maps"] in TRUELIST)
-        output_file = $(cfg["output_file"])
-        write_max_cur_maps = $(cfg["write_max_cur_maps"] in TRUELIST)
-        write_volt_maps = $(cfg["write_volt_maps"] in TRUELIST)
-        set_null_currents_to_nodata = $(cfg["set_null_currents_to_nodata"] in TRUELIST)
-        set_null_voltages_to_nodata = $(cfg["set_null_voltages_to_nodata"] in TRUELIST)
-        compress_grids = $(cfg["compress_grids"] in TRUELIST)
-        write_cur_maps = $(cfg["write_cur_maps"] in TRUELIST)
+        write_cum_cur_map_only = $(cfg.write_cum_cur_map_only)
+        log_transform_maps = $(cfg.log_transform_maps)
+        output_file = $(cfg.output_file)
+        write_max_cur_maps = $(cfg.write_max_cur_maps)
+        write_volt_maps = $(cfg.write_volt_maps)
+        set_null_currents_to_nodata = $(cfg.set_null_currents_to_nodata)
+        set_null_voltages_to_nodata = $(cfg.set_null_voltages_to_nodata)
+        compress_grids = $(cfg.compress_grids)
+        write_cur_maps = $(cfg.write_cur_maps)
         """)
     end
 end
 
+# Keep backward compat for Dict-based write_config
+function write_config(cfg::Dict{String,String})
+    write_config(CSConfig(cfg))
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -67,17 +67,17 @@ function single_ground_all_pairs(prob::GraphProblem{T,V,W}, flags, cfg, log = tr
 end
 
 function get_solver(cfg)
-    s = cfg["solver"]
-    if s in AMG
-        csinfo("Solver used: AMG accelerated by CG", cfg["suppress_messages"] in TRUELIST)
+    s = cfg.solver
+    if s == st_cg_amg
+        csinfo("Solver used: AMG accelerated by CG", cfg.suppress_messages)
         return AMGSolver()
-    elseif s in CHOLMOD
-        csinfo("Solver used: CHOLMOD", cfg["suppress_messages"] in TRUELIST)
-        bs = parse(Int, cfg["cholmod_batch_size"])
+    elseif s == st_cholmod
+        csinfo("Solver used: CHOLMOD", cfg.suppress_messages)
+        bs = cfg.cholmod_batch_size
         return CholmodSolver(bs)
-    elseif s in PARDISO
-        csinfo("Solver used: Pardiso", cfg["suppress_messages"] in TRUELIST)
-        bs = parse(Int, cfg["cholmod_batch_size"])
+    elseif s == st_pardiso
+        csinfo("Solver used: Pardiso", cfg.suppress_messages)
+        bs = cfg.cholmod_batch_size
         return PardisoSolver(bs)
     end
 
@@ -111,10 +111,10 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
 
     cum = prob.cum
 
-    csinfo("Graph has $(size(a,1)) nodes, $numpoints focal points and $(length(cc)) connected components", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Graph has $(size(a,1)) nodes, $numpoints focal points and $(length(cc)) connected components", cfg.suppress_messages)
 
     num, d = get_num_pairs(cc, points, exclude)
-    log && csinfo("Total number of pair solves = $num", cfg["suppress_messages"] in TRUELIST)
+    log && csinfo("Total number of pair solves = $num", cfg.suppress_messages)
 
     # Initialize pairwise resistance
     resistances = -1 * ones(T, numpoints, numpoints)::Matrix{T}
@@ -129,9 +129,9 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
             !write_cum_cur_map_only && !write_max_cur_maps &&
             isempty(exclude)
         get_shortcut_resistances = true
-        csinfo("Triggering resistance calculation shortcut", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Triggering resistance calculation shortcut", cfg.suppress_messages)
         num, d = get_num_pairs_shortcut(cc, points, exclude)
-        csinfo("Total number of pair solves has been reduced to $num ", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Total number of pair solves has been reduced to $num ", cfg.suppress_messages)
     end
     shortcut = Shortcut(get_shortcut_resistances, voltmatrix, shortcut_res)
 
@@ -153,11 +153,11 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
 
         # Construct preconditioner *once* for every CC
         t1 = @elapsed P = aspreconditioner(smoothed_aggregation(matrix))
-        csinfo("Time taken to construct preconditioner = $t1 seconds", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Time taken to construct preconditioner = $t1 seconds", cfg.suppress_messages)
 
         # Get local nodemap for CC - useful for output writing
         t2 = @elapsed local_nodemap = construct_local_node_map(nodemap, comp, polymap)
-        csinfo("Time taken to construct local nodemap = $t2 seconds", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Time taken to construct local nodemap = $t2 seconds", cfg.suppress_messages)
 
         component_data = ComponentData(comp, matrix, local_nodemap, hbmeta, cellmap)
 
@@ -180,7 +180,7 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
             if nprocs() > 1
                 for j in rng
                     pj = csub[j]
-                    csinfo("Scheduling pair $(d[(pi,pj)]) of $num to be solved", cfg["suppress_messages"] in TRUELIST)
+                    csinfo("Scheduling pair $(d[(pi,pj)]) of $num to be solved", cfg.suppress_messages)
                 end
             end
 
@@ -211,9 +211,9 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
 
                         # Solve system
                         # csinfo("Solving points $pi and $pj")
-                        log && csinfo("Solving pair $(d[(pi,pj)]) of $num", cfg["suppress_messages"] in TRUELIST)
+                        log && csinfo("Solving pair $(d[(pi,pj)]) of $num", cfg.suppress_messages)
                         t2 = @elapsed v = solve_linear_system(matrix, current, P)
-                        csinfo("Time taken to solve linear system = $t2 seconds", cfg["suppress_messages"] in TRUELIST)
+                        csinfo("Time taken to solve linear system = $t2 seconds", cfg.suppress_messages)
 
                         v .= v .- v[comp_i]
 
@@ -244,7 +244,7 @@ function solve(prob::GraphProblem{T,V}, ::AMGSolver, flags, cfg, log)::Matrix{T}
             f(1)
             update_shortcut_resistances!(idx, shortcut, resistances, points, comp)
         else
-            is_parallel = cfg["parallelize"] in TRUELIST
+            is_parallel = cfg.parallelize
             if is_parallel
                 X = pmap(x ->f(x), 1:size(csub,1))
             else
@@ -315,10 +315,10 @@ function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, PardisoSolv
     # Get number of focal points
     numpoints = size(points, 1)
 
-    csinfo("Graph has $(size(a,1)) nodes, $numpoints focal points and $(length(cc)) connected components", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Graph has $(size(a,1)) nodes, $numpoints focal points and $(length(cc)) connected components", cfg.suppress_messages)
 
     num, d = get_num_pairs(cc, points, exclude)
-    log && csinfo("Total number of pair solves = $num", cfg["suppress_messages"] in TRUELIST)
+    log && csinfo("Total number of pair solves = $num", cfg.suppress_messages)
 
     # Initialize pairwise resistance
     resistances = -1 * ones(eltype(a), numpoints, numpoints)
@@ -333,9 +333,9 @@ function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, PardisoSolv
             !write_cum_cur_map_only  && !write_max_cur_maps &&
             isempty(exclude)
         get_shortcut_resistances = true
-        csinfo("Triggering resistance calculation shortcut", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Triggering resistance calculation shortcut", cfg.suppress_messages)
         num, d = get_num_pairs_shortcut(cc, points, exclude)
-        csinfo("Total number of pair solves has been reduced to $num ", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Total number of pair solves has been reduced to $num ", cfg.suppress_messages)
     end
     shortcut = Shortcut(get_shortcut_resistances, voltmatrix, shortcut_res)
 
@@ -352,11 +352,11 @@ function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, PardisoSolv
         # Conductance matrix corresponding to CC
         matrix = comps[cid]
 
-        t = @elapsed factor = construct_cholesky_factor(matrix, solver, cfg["suppress_messages"] in TRUELIST)
+        t = @elapsed factor = construct_cholesky_factor(matrix, solver, cfg.suppress_messages)
 
         # Get local nodemap for CC - useful for output writing
         t2 = @elapsed local_nodemap = construct_local_node_map(nodemap, comp, polymap)
-        csinfo("Time taken to construct local nodemap = $t2 seconds", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Time taken to construct local nodemap = $t2 seconds", cfg.suppress_messages)
 
         component_data = ComponentData(comp, matrix, local_nodemap, hbmeta, cellmap)
 
@@ -423,7 +423,7 @@ function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, PardisoSolv
             rng = st + batch_size <= l ?
                             (st:(st+batch_size-1)) : (st:l)
 
-            csinfo("Solving points $(rng.start) to $(rng.stop)", cfg["suppress_messages"] in TRUELIST)
+            csinfo("Solving points $(rng.start) to $(rng.stop)", cfg.suppress_messages)
 
             rhs = zeros(eltype(matrix), size(matrix, 1), length(rng))
 
@@ -444,7 +444,7 @@ function solve(prob::GraphProblem{T,V}, solver::Union{CholmodSolver, PardisoSolv
                 end
             end
 
-            is_parallel = cfg["parallelize"] in TRUELIST
+            is_parallel = cfg.parallelize
             if is_parallel
                 X = pmap(x -> f(x, rng, lhs), 1:length(rng))
             else
@@ -637,14 +637,14 @@ function postprocess(output, component_data, flags, shortcut, cfg)
 
     if flags.outputflags.write_volt_maps
         t = @elapsed write_volt_maps(name, output, component_data, flags, cfg)
-        csinfo("Time taken to write voltage maps = $t seconds", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Time taken to write voltage maps = $t seconds", cfg.suppress_messages)
     end
 
     # TODO: Even though this function is called write_cur_maps
     # actually writing the calculated maps depends on some flags.
     t = @elapsed write_cur_maps(name, output, component_data,
                                 [-9999.], flags, cfg)
-    csinfo("Time taken to calculate current maps = $t seconds", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Time taken to calculate current maps = $t seconds", cfg.suppress_messages)
     nothing
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -254,8 +254,8 @@ function read_source_and_ground_maps(T, V, source_file, ground_file, habitatmeta
 
     ground_map = Matrix{T}(undef,0,0)
     source_map = Matrix{T}(undef,0,0)
-	use_unit_currents = cfg["use_unit_currents"] in TRUELIST
-	use_direct_grounds = cfg["use_direct_grounds"] in TRUELIST
+	use_unit_currents = cfg.use_unit_currents
+	use_direct_grounds = cfg.use_direct_grounds
 
     f = _open(ground_file)
     filetype = _guess_file_type(ground_file, f)
@@ -386,13 +386,13 @@ end
 
 function get_network_data(T, V, cfg)::NetworkData{T,V}
 
-    hab_is_res = cfg["habitat_map_is_resistances"] in TRUELIST
-    hab_file = cfg["habitat_file"]
-    fp_file = cfg["point_file"]
-    source_file = cfg["source_file"]
-    ground_file = cfg["ground_file"]
+    hab_is_res = cfg.habitat_map_is_resistances
+    hab_file = cfg.habitat_file
+    fp_file = cfg.point_file
+    source_file = cfg.source_file
+    ground_file = cfg.ground_file
 
-    is_pairwise = cfg["scenario"] in PAIRWISE
+    is_pairwise = cfg.scenario == sc_pairwise
 
     i,j,v,starts_from_zero = load_graph(V, hab_file, T)
 
@@ -420,45 +420,45 @@ end
 function load_raster_data(T, V, cfg)::RasterData{T,V}
 
     # Habitat file
-    hab_file = cfg["habitat_file"]
-    hab_is_res = cfg["habitat_map_is_resistances"] in TRUELIST
+    hab_file = cfg.habitat_file
+    hab_is_res = cfg.habitat_map_is_resistances
 
     # Polygons
-    use_polygons = cfg["use_polygons"] in TRUELIST
-    polygon_file = cfg["polygon_file"]
+    use_polygons = cfg.use_polygons
+    polygon_file = cfg.polygon_file
 
     # Mask file
-    use_mask = cfg["use_mask"] in TRUELIST
-    mask_file = cfg["mask_file"]
+    use_mask = cfg.use_mask
+    mask_file = cfg.mask_file
 
     # Point file
-    point_file = cfg["point_file"]
+    point_file = cfg.point_file
 
     # Variable source strengths
-    use_var_source = cfg["use_variable_source_strengths"] in TRUELIST
-    var_source_file = cfg["variable_source_file"]
+    use_var_source = cfg.use_variable_source_strengths
+    var_source_file = cfg.variable_source_file
 
     # Included Pairs
-    use_inc_pairs = cfg["use_included_pairs"] in TRUELIST
-    inc_pairs_file = cfg["included_pairs_file"]
+    use_inc_pairs = cfg.use_included_pairs
+    inc_pairs_file = cfg.included_pairs_file
 
     # Advanced mode
-    is_pairwise = cfg["scenario"] in PAIRWISE
-    is_advanced = cfg["scenario"] in ADVANCED
-    source_file = cfg["source_file"]
-    ground_file = cfg["ground_file"]
-    ground_is_res = cfg["ground_file_is_resistances"] in TRUELIST
+    is_pairwise = cfg.scenario == sc_pairwise
+    is_advanced = cfg.scenario == sc_advanced
+    source_file = cfg.source_file
+    ground_file = cfg.ground_file
+    ground_is_res = cfg.ground_file_is_resistances
 
-    csinfo("Reading maps", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Reading maps", cfg.suppress_messages)
 
     # Read cell map
     cellmap, hbmeta = read_cellmap(hab_file, hab_is_res, T)
     c = count(x -> x > 0, cellmap)
     ncells = length(cellmap)
-    if ncells > 5_000_000 && cfg["solver"] in CHOLMOD
+    if ncells > 5_000_000 && cfg.solver == st_cholmod
         cswarn("The landscape has $(ncells) cells and the CHOLMOD solver is selected. CHOLMOD is a sparse direct solver that consumes a lot of memory on large grids. Consider using solver = cg+amg instead.")
     end
-    csinfo("Resistance/Conductance map has $c nodes", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Resistance/Conductance map has $c nodes", cfg.suppress_messages)
 
     # Read polymap
     if use_polygons

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -31,21 +31,21 @@ function cswarn(msg)
     end
 end
 
-function update_logging!(cfg)
+function update_logging!(cfg::CSConfig)
 
-    log_level = cfg["log_level"]
-    log_file = cfg["log_file"]
+    log_level = cfg.log_level
+    log_file = cfg.log_file
 
-    if log_level in DEBUG
+    if log_level == ll_debug
         Logging.LogLevel(Logging.Debug)
-    elseif log_level in WARNING
+    elseif log_level == ll_warning
         Logging.LogLevel(Logging.Warn)
     end
 
-    if log_file != "None"
+    if log_file != ""
         logging["file_logger"] = SimpleLogger(open(log_file, "w+"))
         logging["log_to_file"] = true
-        csinfo("Logs will recorded to file: log_file", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Logs will recorded to file: $log_file", cfg.suppress_messages)
     else
         logging["file_logger"] = SimpleLogger()
         logging["log_to_file"] = false

--- a/src/network/advanced.jl
+++ b/src/network/advanced.jl
@@ -32,10 +32,10 @@ function compute_advanced_data(data::NetworkData{T,V},
 
     cc = connected_components(SimpleWeightedGraph(A))
 	c = size(A,1)
-	csinfo("Graph has $c nodes and $(length(cc)) connected components", cfg["suppress_messages"] in TRUELIST)
+	csinfo("Graph has $c nodes and $(length(cc)) connected components", cfg.suppress_messages)
 
     t = @elapsed G = laplacian(A)
-    csinfo("Time taken to construct graph laplacian = $t", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Time taken to construct graph laplacian = $t", cfg.suppress_messages)
 
     nodemap, polymap = Matrix{V}(undef,0,0), Matrix{V}(undef,0,0)
     cellmap = Matrix{T}(undef,0,0)

--- a/src/network/pairwise.jl
+++ b/src/network/pairwise.jl
@@ -48,10 +48,10 @@ function compute_graph_data(data::NetworkData{T,V}, cfg)::GraphProblem{T,V} wher
 
     cc = connected_components(SimpleWeightedGraph(A))
 	c = size(A,1)
-	csinfo("Graph has $c nodes and $(length(cc)) connected components", cfg["suppress_messages"] in TRUELIST)
+	csinfo("Graph has $c nodes and $(length(cc)) connected components", cfg.suppress_messages)
 
     t = @elapsed G = laplacian(A)
-    csinfo("Time taken to construct graph laplacian = $t", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Time taken to construct graph laplacian = $t", cfg.suppress_messages)
 
     # T = eltype(i)
     exclude_pairs = Tuple{V,V}[]
@@ -73,27 +73,15 @@ function get_network_flags(cfg)
 
     # Computation flags
     is_raster = false
-    is_advanced = cfg["scenario"] in ADVANCED
+    is_advanced = cfg.scenario == sc_advanced
     is_alltoone = false
     is_onetoall = false
-    grnd_file_is_res = cfg["ground_file_is_resistances"] in TRUELIST
-    policy = Symbol(cfg["remove_src_or_gnd"])
-    solver = cfg["solver"]
+    grnd_file_is_res = cfg.ground_file_is_resistances
+    policy = _remove_policy_symbol(cfg.remove_src_or_gnd)
+    solver = _solver_str(cfg.solver)
 
     # Output flags
-    write_volt_maps = cfg["write_volt_maps"] in TRUELIST
-    write_cur_maps = cfg["write_cur_maps"] in TRUELIST
-    write_cum_cur_maps_only = cfg["write_cum_cur_map_only"] in TRUELIST
-    write_max_cur_maps = cfg["write_max_cur_maps"] in TRUELIST
-    set_null_currents_to_nodata = cfg["set_null_currents_to_nodata"] in TRUELIST
-    set_null_voltages_to_nodata = cfg["set_null_voltages_to_nodata"] in TRUELIST
-    compress_grids = cfg["compress_grids"] in TRUELIST
-    log_transform_maps = cfg["log_transform_maps"] in TRUELIST
-
-    o = OutputFlags(write_volt_maps, write_cur_maps,
-                    write_cum_cur_maps_only, write_max_cur_maps,
-                    set_null_currents_to_nodata, set_null_voltages_to_nodata,
-                    compress_grids, log_transform_maps)
+    o = get_output_flags(cfg)
 
     NetworkFlags(is_raster, is_advanced, is_alltoone, is_onetoall,
                 grnd_file_is_res, policy, solver, o)

--- a/src/out.jl
+++ b/src/out.jl
@@ -112,7 +112,7 @@ function write_cur_maps(name, output, component_data, finitegrounds, flags, cfg)
 end
 
 function write_currents(node_curr_arr, branch_curr_arr, name, cfg)
-   pref = split(cfg["output_file"], ".out")[1]
+   pref = split(cfg.output_file, ".out")[1]
    # 1e-6 because we guarantee only 6 digits of precision on solve
    idx = findall(x -> !isapprox(x, 0.0, atol = 1e-6), branch_curr_arr[:,3])
    branch_curr_arr = branch_curr_arr[idx, :]
@@ -148,7 +148,7 @@ function _create_current_maps(G, voltages, finitegrounds, cfg; nodemap = Matrix{
 
     node_currents = get_node_currents(G, voltages, finitegrounds)
 
-    if cfg["data_type"] == "network"
+    if cfg.data_type == dt_network
 
         branch_currents = _get_branch_currents(G, voltages, true)
         branch_currents = abs.(branch_currents)
@@ -329,10 +329,10 @@ function write_grid(cmap, name, cfg, hbmeta;
         str = "voltmap"
     end
 
-    pref = split(cfg["output_file"], ".out")[1]
+    pref = split(cfg.output_file, ".out")[1]
     filename = "$(pref)_$(str)$(name)"
 
-    cfg["write_as_tif"] in TRUELIST ? (file_format = "tif") :
+    cfg.write_as_tif ? (file_format = "tif") :
             (file_format = "asc")
 
     write_raster(filename,
@@ -347,7 +347,7 @@ function write_grid(cmap, name, cfg, hbmeta, cellmap;
                         voltage = false, cum = false, max = false,
                         log_transform = false, set_null_to_nodata = false)
 
-    pref = split(cfg["output_file"], ".out")[1]
+    pref = split(cfg.output_file, ".out")[1]
 
     if log_transform
         map!(x -> x > 0 ? log10(x) : float(hbmeta.nodata), cmap, cmap)
@@ -372,7 +372,7 @@ function write_grid(cmap, name, cfg, hbmeta, cellmap;
 
     filename = "$(pref)_$(str)$(name)"
 
-    cfg["write_as_tif"] in TRUELIST ? (file_format = "tif") :
+    cfg.write_as_tif ? (file_format = "tif") :
             (file_format = "asc")
 
     write_raster(filename,
@@ -389,7 +389,7 @@ function write_volt_maps(name, output, component_data, flags, cfg)
     if !flags.is_raster
 
         cc = component_data.cc
-        write_voltages(cfg["output_file"], name, voltages, cc)
+        write_voltages(cfg.output_file, name, voltages, cc)
 
     else
 
@@ -451,7 +451,7 @@ function accum_currents!(base, newcurr, cfg, G, voltages, finitegrounds, nodemap
 end
 
 function save_resistances(r, cfg)
-    pref = split(cfg["output_file"], ".out")[1]
+    pref = split(cfg.output_file, ".out")[1]
     filename = "$(pref)_resistances.out"
     filename_3col = "$(pref)_resistances_3columns.out"
     rcol = compute_3col(r)
@@ -465,7 +465,7 @@ end
 
 function write_cum_maps(cum, cellmap::Matrix{T}, cfg, hbmeta, write_max, write_cum) where T
 
-    if write_cum || cfg["write_cur_maps"] in TRUELIST
+    if write_cum || cfg.write_cur_maps
         cum_curr = zeros(T, size(cellmap)...)
         for i = 1:nprocs()
             cum_curr .+= cum.cum_curr[i]

--- a/src/raster/advanced.jl
+++ b/src/raster/advanced.jl
@@ -243,7 +243,7 @@ function advanced_kernel(prob::AdvancedProblem{T,V,S}, flags, cfg)::Tuple{Matrix
         return v, outcurr
     end
 
-    scenario = cfg["scenario"]
+    scenario = cfg.scenario
     if !solver_called
         ret = Matrix{T}(undef,1,1)
         ret[1] = -1
@@ -288,7 +288,7 @@ function multiple_solver(cfg, solver, a::SparseMatrixCSC{T,V}, sources, grounds,
     deleteat!(r, dst_del)
     asolve = asolve[r, r]
 
-    volt = multiple_solve(solver, asolve, sources, cfg["suppress_messages"] in TRUELIST)
+    volt = multiple_solve(solver, asolve, sources, cfg.suppress_messages)
 
     # Replace the inf with 0
     voltages = zeros(eltype(a), length(volt) + length(infgrounds))

--- a/src/raster/onetoall.jl
+++ b/src/raster/onetoall.jl
@@ -53,7 +53,7 @@ function onetoall_kernel(data::RasterData{T,V}, flags, cfg)::Matrix{T} where {T,
     a = construct_graph(gmap, nodemap, avg_res, four_neighbors)
     cc = connected_components(SimpleWeightedGraph(a))
     G = laplacian(a)
-    csinfo("There are $(size(a, 1)) points and $(length(cc)) connected components", cfg["suppress_messages"] in TRUELIST)
+    csinfo("There are $(size(a, 1)) points and $(length(cc)) connected components", cfg.suppress_messages)
 
     # source_map = Matrix{eltype(a)}(0, 0)
     # ground_map = Matrix{eltype(a)}(0, 0)
@@ -78,7 +78,7 @@ function onetoall_kernel(data::RasterData{T,V}, flags, cfg)::Matrix{T} where {T,
         # copyto!(point_map, original_point_map)
         point_map = copy(original_point_map)
         str = use_variable_strengths ? strengths[i,2] : 1
-        csinfo("Solving point $i of $num_points_to_solve", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Solving point $i of $num_points_to_solve", cfg.suppress_messages)
         # copyto!(s, z)
         s = copy(z)
         n = points_unique[i]

--- a/src/raster/pairwise.jl
+++ b/src/raster/pairwise.jl
@@ -34,16 +34,15 @@ function get_raster_flags(cfg)
 
     # Computation flags
     is_raster = true
-    is_pairwise = cfg["scenario"] in PAIRWISE
-    is_advanced = cfg["scenario"] in ADVANCED
-    is_onetoall = cfg["scenario"] in ONETOALL
-    is_alltoone = cfg["scenario"] in ALLTOONE
-    four_neighbors = cfg["connect_four_neighbors_only"] in TRUELIST
-    avg_res = cfg["connect_using_avg_resistances"] in TRUELIST
-    solver = cfg["solver"]
-    ground_file_is_resistances =
-        cfg["ground_file_is_resistances"] in TRUELIST
-    policy = Symbol(cfg["remove_src_or_gnd"])
+    is_pairwise = cfg.scenario == sc_pairwise
+    is_advanced = cfg.scenario == sc_advanced
+    is_onetoall = cfg.scenario == sc_onetoall
+    is_alltoone = cfg.scenario == sc_alltoone
+    four_neighbors = cfg.connect_four_neighbors_only
+    avg_res = cfg.connect_using_avg_resistances
+    solver = _solver_str(cfg.solver)
+    ground_file_is_resistances = cfg.ground_file_is_resistances
+    policy = _remove_policy_symbol(cfg.remove_src_or_gnd)
 
     # Output Flags
     o = get_output_flags(cfg)
@@ -102,14 +101,14 @@ function _pt_file_polygons_path(rasterdata::RasterData{T,V},
     resistances = -1 * ones(length(pts), length(pts))
 
     n = calc_num_pairs(pts)
-    csinfo("Total number of pair solves = $n", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Total number of pair solves = $n", cfg.suppress_messages)
 
     k = 1
     for i = 1:size(pts, 1)
         pt1 = pts[i]
         for j = i+1:size(pts, 1)
             pt2 = pts[j]
-            csinfo("Solving pair $k of $n", cfg["suppress_messages"] in TRUELIST)
+            csinfo("Solving pair $k of $n", cfg.suppress_messages)
             k += 1
 			if (pt1,pt2) in exclude_pairs || (pt2, pt1) in exclude_pairs 
 				continue

--- a/src/run.jl
+++ b/src/run.jl
@@ -15,41 +15,41 @@ function compute(path::String)
     cfg = parse_config(path)
     update_logging!(cfg)
     write_config(cfg)
-    T = cfg["precision"] in SINGLE ? Float32 : Float64
-    if T == Float32 && (cfg["solver"] in CHOLMOD || cfg["solver"] in PARDISO)
+    T = cfg.precision == pr_single ? Float32 : Float64
+    if T == Float32 && (cfg.solver == st_cholmod || cfg.solver == st_pardiso)
         cswarn("Cholmod & Pardiso solver modes work only in double precision. Switching precision to double.")
         T = Float64
     end
-    V = cfg["use_64bit_indexing"] in TRUELIST ? Int64 : Int32
-    csinfo("Precision used: $(cfg["precision"])", cfg["suppress_messages"] in TRUELIST)
-    is_parallel = cfg["parallelize"] in TRUELIST
+    V = cfg.use_64bit_indexing ? Int64 : Int32
+    csinfo("Precision used: $(_precision_str(cfg.precision))", cfg.suppress_messages)
+    is_parallel = cfg.parallelize
     if is_parallel
-        n = parse(Int, cfg["max_parallel"])
-        csinfo("Starting up Circuitscape to use $n processes in parallel", cfg["suppress_messages"] in TRUELIST)
+        n = cfg.max_parallel
+        csinfo("Starting up Circuitscape to use $n processes in parallel", cfg.suppress_messages)
         myaddprocs(n)
     end
     t = @elapsed r = _compute(T, V, cfg)
 
-    csinfo("Time taken to complete job = $t", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Time taken to complete job = $t", cfg.suppress_messages)
     is_parallel && rmprocs(workers())
     r
 end
 
 function _compute(T, V, cfg)
-    is_raster = cfg["data_type"] in RASTER
-    scenario = cfg["scenario"]
+    is_raster = cfg.data_type == dt_raster
+    scenario = cfg.scenario
     if is_raster
-        if scenario in PAIRWISE
+        if scenario == sc_pairwise
             raster_pairwise(T, V, cfg)
-        elseif scenario in ADVANCED
+        elseif scenario == sc_advanced
             raster_advanced(T, V, cfg)
-        elseif scenario in ONETOALL
+        elseif scenario == sc_onetoall
             raster_one_to_all(T, V, cfg)
         else
             raster_one_to_all(T, V, cfg)
         end
     else
-        if scenario in PAIRWISE
+        if scenario == sc_pairwise
             network_pairwise(T, V, cfg)
         else
             network_advanced(T, V, cfg)
@@ -58,22 +58,23 @@ function _compute(T, V, cfg)
 end
 
 function compute(dict)
-    cfg = init_config()
-    update!(cfg, dict)
+    cfg_dict = init_config()
+    update!(cfg_dict, dict)
+    cfg = CSConfig(cfg_dict)
     update_logging!(cfg)
     write_config(cfg)
-    T = cfg["precision"] in SINGLE ? Float32 : Float64
-    V = cfg["use_64bit_indexing"] in TRUELIST ? Int64 : Int32
-    csinfo("Precision used: $(cfg["precision"])", cfg["suppress_messages"] in TRUELIST)
-    is_parallel = cfg["parallelize"] in TRUELIST
+    T = cfg.precision == pr_single ? Float32 : Float64
+    V = cfg.use_64bit_indexing ? Int64 : Int32
+    csinfo("Precision used: $(_precision_str(cfg.precision))", cfg.suppress_messages)
+    is_parallel = cfg.parallelize
     if is_parallel
-        n = parse(Int, cfg["max_parallel"])
-        csinfo("Starting up Circuitscape to use $n processes in parallel", cfg["suppress_messages"] in TRUELIST)
+        n = cfg.max_parallel
+        csinfo("Starting up Circuitscape to use $n processes in parallel", cfg.suppress_messages)
         myaddprocs(n)
     end
     t = @elapsed r = _compute(T, V, cfg)
 
-    csinfo("Time taken to complete job = $t", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Time taken to complete job = $t", cfg.suppress_messages)
     is_parallel && rmprocs(workers())
 
     r

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,14 +36,14 @@ end
 function get_output_flags(cfg)
 
     # Output flags
-    write_volt_maps = cfg["write_volt_maps"] in TRUELIST
-    write_cur_maps = cfg["write_cur_maps"] in TRUELIST
-    write_cum_cur_map_only = cfg["write_cum_cur_map_only"] in TRUELIST
-    write_max_cur_maps = cfg["write_max_cur_maps"] in TRUELIST
-    set_null_currents_to_nodata = cfg["set_null_currents_to_nodata"] in TRUELIST
-    set_null_voltages_to_nodata = cfg["set_null_voltages_to_nodata"] in TRUELIST
-    compress_grids = cfg["compress_grids"] in TRUELIST
-    log_transform_maps = cfg["log_transform_maps"] in TRUELIST
+    write_volt_maps = cfg.write_volt_maps
+    write_cur_maps = cfg.write_cur_maps
+    write_cum_cur_map_only = cfg.write_cum_cur_map_only
+    write_max_cur_maps = cfg.write_max_cur_maps
+    set_null_currents_to_nodata = cfg.set_null_currents_to_nodata
+    set_null_voltages_to_nodata = cfg.set_null_voltages_to_nodata
+    compress_grids = cfg.compress_grids
+    log_transform_maps = cfg.log_transform_maps
 
     o = OutputFlags(write_volt_maps, write_cur_maps,
                     write_cum_cur_map_only, write_max_cur_maps,
@@ -97,7 +97,7 @@ function accumulate_current_maps(path, f)
 
     accum = zeros(nrow, ncol)
     for file in cmap_list
-        csinfo("Accumulating $file", cfg["suppress_messages"] in TRUELIST)
+        csinfo("Accumulating $file", cfg.suppress_messages)
         cmap_path = joinpath(dir, file)
         cmap = readdlm(cmap_path, skipstart = 6)
         f_in_place!(accum, cmap, f)
@@ -115,7 +115,7 @@ function accumulate_current_maps(path, f)
             end
 
     accum_path = joinpath(dir, name * "_$(name)_curmap.asc")
-    csinfo("Writing to $accum_path", cfg["suppress_messages"] in TRUELIST)
+    csinfo("Writing to $accum_path", cfg.suppress_messages)
     open(accum_path, "w") do f
         write(f, headers)
         writedlm(f, round.(accum, digits=8), ' ')
@@ -223,13 +223,15 @@ function compute_omniscape_current(
         false, false, false, false
     )
 
+    cfg = CSConfig(cs_cfg)
+
     flags = RasterFlags(
         true, false, true, false, false, false, Symbol("rmvsrc"),
-        cs_cfg["connect_four_neighbors_only"] in TRUELIST, false, 
-        cs_cfg["solver"], o
+        cfg.connect_four_neighbors_only, false, 
+        _solver_str(cfg.solver), o
     )
 
-    data = compute_advanced_data(rasterdata, flags, cs_cfg)
+    data = compute_advanced_data(rasterdata, flags, cfg)
 
     G = data.G
     nodemap = data.nodemap
@@ -267,7 +269,7 @@ function compute_omniscape_current(
             f_local = finitegrounds
         end
 
-        voltages = multiple_solver(cs_cfg,
+        voltages = multiple_solver(cfg,
                                    data.solver,
                                    a_local,
                                    s_local,
@@ -280,7 +282,7 @@ function compute_omniscape_current(
 
         accum_currents!(outcurr,
                         voltages,
-                        cs_cfg,
+                        cfg,
                         a_local,
                         voltages,
                         f_local,

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,51 +2,63 @@ using Circuitscape
 using Test
 using DelimitedFiles
 
-import Circuitscape: parse_config, _compute, SINGLE, CHOLMOD, PARDISO, TRUELIST, cswarn
+import Circuitscape: parse_config, _compute, SINGLE, CHOLMOD, PARDISO, TRUELIST, cswarn,
+                     CSConfig, pr_single, st_cholmod, st_pardiso, _precision_str
 
 function compute_cholmod(str, batch_size = 5)
     cfg = parse_config(str)
-    T = cfg["precision"] in SINGLE ? Float32 : Float64
-    V = cfg["use_64bit_indexing"] in TRUELIST ? Int64 : Int32
+    T = cfg.precision == pr_single ? Float32 : Float64
+    V = cfg.use_64bit_indexing ? Int64 : Int32
     if T == Float32
         cswarn("Cholmod supports only double precision. Changing precision to double.")
         T = Float64
     end
-    cfg["solver"] = "cholmod"
-    cfg["cholmod_batch_size"] = string(batch_size)
-    _compute(T, V, cfg)
+    # Rebuild config with cholmod solver and batch size
+    d = Dict{String,String}(cfg)
+    d["solver"] = "cholmod"
+    d["cholmod_batch_size"] = string(batch_size)
+    cfg2 = CSConfig(d)
+    _compute(T, V, cfg2)
 end
 
 function compute_pardiso(str, batch_size = 5)
     cfg = parse_config(str)
-    T = cfg["precision"] in SINGLE ? Float32 : Float64
-    V = cfg["use_64bit_indexing"] in TRUELIST ? Int64 : Int32
+    T = cfg.precision == pr_single ? Float32 : Float64
+    V = cfg.use_64bit_indexing ? Int64 : Int32
     if T == Float32
         cswarn("Pardiso supports only double precision. Changing precision to double.")
         T = Float64
     end
-    cfg["solver"] = "pardiso"
-    cfg["cholmod_batch_size"] = string(batch_size)
-    _compute(T, V, cfg)
+    # Rebuild config with pardiso solver and batch size
+    d = Dict{String,String}(cfg)
+    d["solver"] = "pardiso"
+    d["cholmod_batch_size"] = string(batch_size)
+    cfg2 = CSConfig(d)
+    _compute(T, V, cfg2)
 end
 
 function compute_single(str)
     cfg = parse_config(str)
-    cfg["precision"] = "single"
-    V = cfg["use_64bit_indexing"] in TRUELIST ? Int64 : Int32
+    # Rebuild config with single precision
+    d = Dict{String,String}(cfg)
+    d["precision"] = "single"
+    cfg2 = CSConfig(d)
+    V = cfg2.use_64bit_indexing ? Int64 : Int32
     T = Float32
-    if cfg["solver"] in CHOLMOD || cfg["solver"] in PARDISO
+    if cfg2.solver == st_cholmod || cfg2.solver == st_pardiso
         cswarn("Cholmod and Pardiso support only double precision. Changing precision to double.")
         T = Float64
     end
-    _compute(T, V, cfg)
+    _compute(T, V, cfg2)
 end
 
 function compute_parallel(str, n_processes = 2)
     cfg = parse_config(str)
-    cfg["parallelize"] = "true"
-    cfg["max_parallel"] = "$(n_processes)"
-    compute(cfg)
+    # Rebuild config with parallel settings
+    d = Dict{String,String}(cfg)
+    d["parallelize"] = "true"
+    d["max_parallel"] = "$(n_processes)"
+    compute(d)
 end
 
 function model_problem(T, s)


### PR DESCRIPTION
## Summary

Depends on #444 (pardiso-extension).

- Replace `Dict{String,String}` config with a typed `CSConfig` struct (49 fields with proper Bool/enum/Int/String types)
- Eliminates string parsing in hot paths — `cfg["suppress_messages"] in TRUELIST` becomes `cfg.suppress_messages` (direct Bool access)
- Full backward compatibility: `compute(dict::Dict)` and `init_config()` still work

## What changed

- New `CSConfig` struct with `@kwdef` and 6 enums (`DataType`, `Scenario`, `SolverType`, `Precision`, `LogLevel`, `RemovePolicy`)
- `CSConfig(::Dict{String,String})` constructor for backward compat
- `parse_config` now returns `CSConfig`
- ~80 `cfg["..."] in TRUELIST` / `cfg["..."]` sites replaced with direct field access across 13 files
- `compute_omniscape_current` still accepts `Dict{String,String}`, converts internally
- `init_config()` still returns `Dict{String,String}` for Omniscape.jl compat

## Backward compatibility

- `compute("path/to/file.ini")` — works as before
- `compute(dict)` where dict is `Dict{String,String}` — works, converts at boundary
- `init_config()` — still returns Dict
- INI file format — unchanged

## Test plan

- [x] All 719 tests pass
- [x] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)