### PR TITLE
Bump version to 5.17.1 and add GZip 0.7 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Circuitscape"
 uuid = "2b7a1792-8151-5239-925d-e2b8fdfa3201"
-version = "5.17.0"
+version = "5.17.1"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
@@ -30,7 +30,7 @@ AlgebraicMultigrid = "1.2"
 AppleAccelerate = "0.6"
 ArchGDAL = "0.10"
 DelimitedFiles = "1.9"
-GZip = "0.6"
+GZip = "0.6, 0.7"
 Graphs = "1"
 Krylov = "0.10"
 Pardiso = "1.1"


### PR DESCRIPTION
## Summary
- Add GZip 0.7 to compat bounds (retaining 0.6 support)
- Bump project version to 5.17.1

## Test plan
- [ ] Verify package precompiles and tests pass with GZip 0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)